### PR TITLE
Miscellaneous changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,19 @@ Building
 Running
 -------
 
-    ./search-insights-collector.sh [--collect-host-metrics | --collect-zk-metrics | --collect-solr-metrics | --zkhost <zkhost>]
+    ./search-insights-collector.sh [--collect-host-metrics | --collect-zk-metrics | --collect-solr-metrics | --zkhost <zkhost> | -d <comma separated list of Solr hosts>]
 
-    Example:  ./search-insights-collector.sh --collect-host-metrics --collect-zk-metrics --collect-solr-metrics --zkhost zk1:2181
+    Examples:
+    
+    #  ./search-insights-collector.sh --collect-host-metrics --collect-zk-metrics --collect-solr-metrics --zkhost myzookeeperhost1:2181
 
-    Note: --zkhost parameter is necessary if using --collect-solr-metrics or --collect-zk-metrics
+    #  ./search-insights-collector.sh --collect-solr-metrics -d http://solr1:8983/solr,http://solr2:8983/solr
+
+    Notes:
+    
+    # --zkhost parameter is necessary if using --collect-zk-metrics
+    # To supply Solr URLs directly, use -d parameter. If not specified, Solr URLs will be looked up in live_nodes of ZooKeeper (if --zkhost is specified)
+    # To disable collection of logs and field metrics (Luke), you can add --disable-expensive-operations parameter
 
 Outputs
 -------

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Building
 Running
 -------
 
-    ./search-insights-collector.sh [--collect-host-metrics | --collect-zk-metrics | --collect-solr-metrics | --zkhost <zkhost> | -d <comma separated list of Solr hosts>]
+    ./search-insights-collector.sh [--collect-host-metrics | --collect-zk-metrics | --collect-solr-metrics | --zkhost <zkhost> | -d <comma separated list of Solr hosts> | -n <clustername>]
 
     Examples:
     
@@ -23,6 +23,7 @@ Running
     # --zkhost parameter is necessary if using --collect-zk-metrics
     # To supply Solr URLs directly, use -d parameter. If not specified, Solr URLs will be looked up in live_nodes of ZooKeeper (if --zkhost is specified)
     # To disable collection of logs and field metrics (Luke), you can add --disable-expensive-operations parameter
+    # If you have multiple Solr clusters, you can specify `-n <clustername>` parameter to ensure the generated file contains the cluster name in prefix. The name shouldn't contain spaces or special characters (other than '-').
 
 Outputs
 -------

--- a/README.md
+++ b/README.md
@@ -10,20 +10,21 @@ Building
 Running
 -------
 
+Syntax:
+
     ./search-insights-collector.sh [--collect-host-metrics | --collect-zk-metrics | --collect-solr-metrics | --zkhost <zkhost> | -d <comma separated list of Solr hosts> | -n <clustername>]
 
-    Examples:
+Examples:
     
-    #  ./search-insights-collector.sh --collect-host-metrics --collect-zk-metrics --collect-solr-metrics --zkhost myzookeeperhost1:2181
+*  `./search-insights-collector.sh --collect-host-metrics --collect-zk-metrics --collect-solr-metrics --zkhost myzookeeperhost1:2181`
+*  `./search-insights-collector.sh --collect-solr-metrics -d http://solr1:8983/solr,http://solr2:8983/solr`
 
-    #  ./search-insights-collector.sh --collect-solr-metrics -d http://solr1:8983/solr,http://solr2:8983/solr
-
-    Notes:
+Notes:
     
-    # --zkhost parameter is necessary if using --collect-zk-metrics
-    # To supply Solr URLs directly, use -d parameter. If not specified, Solr URLs will be looked up in live_nodes of ZooKeeper (if --zkhost is specified)
-    # To disable collection of logs and field metrics (Luke), you can add --disable-expensive-operations parameter
-    # If you have multiple Solr clusters, you can specify `-n <clustername>` parameter to ensure the generated file contains the cluster name in prefix. The name shouldn't contain spaces or special characters (other than '-').
+* `--zkhost` parameter is necessary if using `--collect-zk-metrics`
+* To supply Solr URLs directly, use `-d` parameter. If not specified, Solr URLs will be looked up in live_nodes of ZooKeeper (if `--zkhost` is specified)
+* To disable collection of logs and field metrics (Luke), you can add `--disable-expensive-operations` parameter
+* If you have multiple Solr clusters, you can specify `-n <clustername>` parameter to ensure the generated file contains the cluster name in prefix. The name shouldn't contain spaces or special characters (other than '-').
 
 Outputs
 -------

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.searchscale.insights</groupId>
   <artifactId>search-insights-collector</artifactId>
   <packaging>jar</packaging>
-  <version>0.7</version>
+  <version>0.8</version>
   <name>search-insights-collector</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,18 @@
           <target>1.8</target>
         </configuration>
       </plugin>
-
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-jar-plugin</artifactId>
+    <configuration>
+        <archive>                   
+            <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+            </manifest>
+        </archive>
+    </configuration>
+</plugin>
          <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
             <executions>
@@ -75,6 +86,8 @@
                <archive>
                   <manifest>
                      <mainClass>com.searchscale.SearchInsightsCollector</mainClass>
+                     <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                     <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                   </manifest>
                </archive>
                <descriptorRefs>

--- a/search-insights-collector.sh
+++ b/search-insights-collector.sh
@@ -65,7 +65,7 @@ then
 fi
 
 ######### COMPUTE THE SOLR and ZOOKEEPER METRICS ############
-java -cp search-insights-collector-0.7-jar-with-dependencies.jar:target/search-insights-collector-0.7-jar-with-dependencies.jar:. \
+java -cp search-insights-collector-0.8-jar-with-dependencies.jar:target/search-insights-collector-0.8-jar-with-dependencies.jar:. \
          com.searchscale.insights.SearchInsightsCollector -c $ZKHOST --output-directory $OUTDIR $JAVA_OPTS
 
 ############ PREPARE THE TARBALL ###############

--- a/search-insights-collector.sh
+++ b/search-insights-collector.sh
@@ -1,5 +1,5 @@
 ################### OPTIONS PARSING #####################
-VALID_ARGS=$(getopt -o hszc: --long collect-host-metrics,collect-solr-metrics,collect-zk-metrics,zkhost: -- "$@")
+VALID_ARGS=$(getopt -o ehszcd: --long disable-expensive-operations,collect-host-metrics,collect-solr-metrics,collect-zk-metrics,zkhost: -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1;
 fi
@@ -9,6 +9,11 @@ JAVA_OPTS=""
 eval set -- "$VALID_ARGS"
 while [ : ]; do
   case "$1" in
+    -e | --disable-expensive-operations)
+        DISABLE_EXPENSIVE="True"
+        JAVA_OPTS="$JAVA_OPTS --disable-expensive-operations"
+        shift
+        ;;
     -h | --collect-host-metrics)
         HOST_METRICS="True"
         JAVA_OPTS="$JAVA_OPTS --collect-host-metrics"
@@ -24,6 +29,12 @@ while [ : ]; do
         ;;
     -c | --zkhost)
         ZKHOST=$2
+        JAVA_OPTS="$JAVA_OPTS -c $ZKHOST"
+        shift 2
+        ;;
+    -d )
+        SOLRURLS=$2
+        JAVA_OPTS="$JAVA_OPTS -d $SOLRURLS"
         shift 2
         ;;
     --) shift; 
@@ -32,20 +43,14 @@ while [ : ]; do
   esac
 done
 
-
 ############ INIT ###############
 TIMESTAMP=`date +"%Y_%m_%d-%H_%M_%S"`_$RANDOM
 OUTDIR=searchinsights-$TIMESTAMP
-
-echo "ZK Host: $ZKHOST"
-
 mkdir -p $OUTDIR
 
 ################ COMPUTE THE HOST METRICS #######################
-
 if [[ "True" == "$HOST_METRICS" ]];
 then
-
 	mkdir -p $OUTDIR/host
 
 	c=0
@@ -55,18 +60,17 @@ then
 	  if ! (( $c % 2 )) ; then
 	    key=$prevLine
 	    cmd=$line
-	    # echo "Command: $cmd..."
 	    $cmd >> $OUTDIR/host/$key.txt
-	    echo "Written $OUTDIR/host/$key.txt file"
+	    #echo "Written $OUTDIR/host/$key.txt file"
 	  fi
-	
 	  prevLine=$line
 	done < <(jq -r ".|to_entries[][]" host-metrics.json)
+  echo "Done collecting host metrics in $OUTDIR/host directory"
 fi
 
 ######### COMPUTE THE SOLR and ZOOKEEPER METRICS ############
 java -cp search-insights-collector-0.8-jar-with-dependencies.jar:target/search-insights-collector-0.8-jar-with-dependencies.jar:. \
-         com.searchscale.insights.SearchInsightsCollector -c $ZKHOST --output-directory $OUTDIR $JAVA_OPTS
+         com.searchscale.insights.SearchInsightsCollector --output-directory $OUTDIR $JAVA_OPTS
 
 ############ PREPARE THE TARBALL ###############
 filename="collector-$TIMESTAMP.tar"

--- a/src/main/java/com/searchscale/insights/SearchInsightsCollector.java
+++ b/src/main/java/com/searchscale/insights/SearchInsightsCollector.java
@@ -45,6 +45,7 @@ public class SearchInsightsCollector
 		options.addOption("s", "collect-solr-metrics", false, "Collect Solr Metrics");
 		options.addOption("z", "collect-zk-metrics",   false, "Collect ZK Metrics");
 		options.addOption("e", "disable-expensive-operations",   false, "Don't collect Luke, logs etc.");
+		options.addOption("n", "cluster-name",   true, "Name of the cluster (no spaces)");
 		options.addRequiredOption("o", "output-directory", true, "Output Directory");
 
 		CommandLineParser parser = new DefaultParser();

--- a/src/main/java/com/searchscale/insights/SearchInsightsCollector.java
+++ b/src/main/java/com/searchscale/insights/SearchInsightsCollector.java
@@ -55,6 +55,8 @@ public class SearchInsightsCollector
 
 	public static void main( String[] args ) throws Exception
 	{
+		
+		
 		CommandLine cmd = getParsedCLICommands(args);
 		String zkhost = getZKHost(cmd);
 		String directSolrUrls[] = getDirectSolrURLs(cmd);
@@ -68,6 +70,8 @@ public class SearchInsightsCollector
 			}
 		}
 
+		String collectorVersion = (SearchInsightsCollector.class.getPackage().getImplementationVersion());
+		FileUtils.write(new File(outputDirectory + File.separatorChar + "collector.properties"), "collector-version=" + collectorVersion + "\n", Charset.forName("UTF-8"));
 		if (cmd.hasOption("collect-zk-metrics")) {
 			if (zkhost == null || zkhost.isBlank()) throw new RuntimeException("--collect-zk-metrics was specified but ZK host (-c / --zkhost) not specified.");
 			System.out.println("Started collecting ZK metrics...");

--- a/src/main/java/com/searchscale/insights/SearchInsightsCollector.java
+++ b/src/main/java/com/searchscale/insights/SearchInsightsCollector.java
@@ -8,8 +8,12 @@ import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,9 +40,11 @@ public class SearchInsightsCollector
 	private static CommandLine getParsedCLICommands(String[] args) throws ParseException {
 		Options options = new Options();
 		options.addOption("c", "zkhost", true, "ZK host (with chroot, if applicable), example: zk-host:2181 or zk-host1:2181/solr");
+		options.addOption("d", "direct-solr-urls", true, "Direct Solr URLs (comma separated), example: http://solr2:8983/solr,http://solr1:8983/solr");
 		options.addOption("h", "collect-host-metrics", false, "Collect Host Metrics");
 		options.addOption("s", "collect-solr-metrics", false, "Collect Solr Metrics");
 		options.addOption("z", "collect-zk-metrics",   false, "Collect ZK Metrics");
+		options.addOption("e", "disable-expensive-operations",   false, "Don't collect Luke, logs etc.");
 		options.addRequiredOption("o", "output-directory", true, "Output Directory");
 
 		CommandLineParser parser = new DefaultParser();
@@ -48,10 +54,11 @@ public class SearchInsightsCollector
 
 	public static void main( String[] args ) throws Exception
 	{
-		String zkhost = null;
-
 		CommandLine cmd = getParsedCLICommands(args);
-		zkhost = getZKHosts(cmd, zkhost);
+		String zkhost = getZKHost(cmd);
+		String directSolrUrls[] = getDirectSolrURLs(cmd);
+		boolean disableExpensiveOps = cmd.hasOption("disable-expensive-operations") ? true: false;
+		if (disableExpensiveOps) System.out.println("Expensive operations are disabled!");
 
 		String outputDirectory = cmd.getOptionValue("o");
 		if (!(new File(outputDirectory).exists() && new File(outputDirectory).isDirectory())) {
@@ -61,6 +68,8 @@ public class SearchInsightsCollector
 		}
 
 		if (cmd.hasOption("collect-zk-metrics")) {
+			if (zkhost == null || zkhost.isBlank()) throw new RuntimeException("--collect-zk-metrics was specified but ZK host (-c / --zkhost) not specified.");
+			System.out.println("Started collecting ZK metrics...");
 			CuratorFramework client = CuratorFrameworkFactory.newClient(zkhost, new RetryNTimes(3, 500));
 			client.start();
 			Map<String, String> zkDump = dumpZkData(client, "/");
@@ -70,68 +79,64 @@ public class SearchInsightsCollector
 			new ObjectMapper().writeValue(writer, zkDump);
 			writer.close();
 			client.close();
+			System.out.println("Done ZK metrics!");
 		}
 
 		if (cmd.hasOption("collect-solr-metrics")) {
-			CuratorFramework client = CuratorFrameworkFactory.newClient(zkhost, new RetryNTimes(3, 500));
-			String clusterStateOutput = null;
-			client.start();
-			List<String> solrHostURLs = getSolrURLs(client);
+			System.out.println("Started collecting Solr metrics...");
+			List<String> solrHostURLs = null;
 
-			for (String solrHost: solrHostURLs ) {
-				// System.out.println("Reading metrics from " + solrHost + "...");
-				String metricsOutput = fetchURL(solrHost + "/admin/metrics");
-				String metricsDir = outputDirectory + File.separatorChar + "solr" + File.separatorChar + "metrics";
-				new File(metricsDir).mkdirs();
-				FileUtils.write(
-						new File((metricsDir + File.separatorChar) + (solrHost.replaceAll("/", "_"))),
-						metricsOutput, Charset.forName("UTF-8"));
-
-				// System.out.println("Reading Cluster State through " + solrHost + "...");
-				clusterStateOutput = fetchURL(solrHost + "/admin/collections?action=CLUSTERSTATUS");
-				String clusterStateDir = outputDirectory + File.separatorChar + "solr" + File.separatorChar + "clusterstate";
-				new File(clusterStateDir).mkdirs();
-				FileUtils.write(
-						new File(clusterStateDir + File.separatorChar + (solrHost.replaceAll("/", "_"))),
-						clusterStateOutput, Charset.forName("UTF-8"));
+			if (directSolrUrls != null) {
+				solrHostURLs = Arrays.asList(directSolrUrls);
+			} else {
+				CuratorFramework client = CuratorFrameworkFactory.newClient(zkhost, new RetryNTimes(3, 500));
+				client.start();
+				solrHostURLs = getSolrURLs(client);
+				client.close();
 			}
 
-			if (clusterStateOutput != null) {
-				// Use the last fetched cluster state to now fetch segments and luke info:
-				Map<String, Object> cluster = new ObjectMapper().readValue(clusterStateOutput, Map.class);
-				Map<String, Map> collections = ((Map<String, Map>)cluster.get("cluster")).get("collections");
-				for (String collectionName: collections.keySet()) {
-					Map coll = collections.get(collectionName);
-					Map<String, Map> shards = (Map<String, Map>)coll.get("shards");
-					for (String shardName: shards.keySet()) {
-						Map<String, Map> shard = (Map<String, Map>) shards.get(shardName);
-						Map<String, Map<String, String>> replicas = (Map<String, Map<String, String>>)shard.get("replicas");
-						for (String coreNodeName: replicas.keySet()) {
-							Map<String, String> replica = replicas.get(coreNodeName);
-							boolean leader = Boolean.valueOf(replica.get("leader"));
-							if (!leader) continue;
-							String core = replica.get("core");
-							String baseUrl = replica.get("base_url");
-							// Fetch
-							String segmentsOutput = fetchURL(baseUrl + "/" + core + "/admin/segments");
-							String lukeOutput = fetchURL(baseUrl + "/" + core + "/admin/luke");
-							// Write
-							String coresInfoDir = outputDirectory + File.separatorChar + "solr" + File.separatorChar + "cores";
-							new File(coresInfoDir).mkdirs();
-							FileUtils.write(
-									new File(coresInfoDir + File.separatorChar + core+"_segments"),
-									segmentsOutput, Charset.forName("UTF-8"));
-							FileUtils.write(
-									new File(coresInfoDir + File.separatorChar + core+"_luke"),
-									lukeOutput, Charset.forName("UTF-8"));
-						}
+			System.out.println("Solr URLs are: " + solrHostURLs);
+			for (String solrHost: solrHostURLs ) {
+				if (solrHost.endsWith("/solr") == false) {
+					solrHost += solrHost.endsWith("/")? "solr": "/solr";
+				}
+
+				collectSolrNodeLevelEndpoint("metrics", solrHost + "/admin/metrics", solrHost, outputDirectory);
+				collectSolrNodeLevelEndpoint("threads", solrHost + "/admin/info/threads", solrHost, outputDirectory);
+				if (!disableExpensiveOps) {
+					collectSolrNodeLevelEndpoint("logs", solrHost + "/admin/info/logging?since=" + LocalDateTime.now().minusDays(1).toEpochSecond(ZoneOffset.UTC), solrHost, outputDirectory);
+				}
+				collectSolrNodeLevelEndpoint("clusterstate", solrHost + "/admin/collections?action=CLUSTERSTATUS", solrHost, outputDirectory);
+				collectSolrNodeLevelEndpoint("overseer", solrHost + "/admin/collections?action=OVERSEERSTATUS", solrHost, outputDirectory);
+				String coresOutput = collectSolrNodeLevelEndpoint("cores", solrHost + "/admin/cores", solrHost, outputDirectory);
+
+				for (String core: ((Map<String, Object>)new ObjectMapper().readValue(coresOutput, Map.class).get("status")).keySet()) {
+					String coresInfoDir = outputDirectory + File.separatorChar + "solr" + File.separatorChar + "cores";
+					new File(coresInfoDir).mkdirs();
+
+					System.out.println("\tFor core " + core);
+					for (String adminEndpoint: new String[] {"segments", disableExpensiveOps? null: "luke", "plugins"}) {
+						if (adminEndpoint==null) continue;
+						System.out.println("\t\tReading " + adminEndpoint + "...");
+						String output = fetchURL(solrHost + "/" + core + "/admin/" + adminEndpoint);
+						FileUtils.write(new File(coresInfoDir + File.separatorChar + core + "_" + adminEndpoint), output, Charset.forName("UTF-8"));
 					}
 				}
 			}
-
-			client.close();
 		}    	
 	}
+
+	private static String collectSolrNodeLevelEndpoint(String item, String endpoint, String solrHost, String outputDirectory) throws MalformedURLException, ProtocolException, IOException {
+		System.out.println("Reading " + item + " from " + solrHost + "...");
+		String output = fetchURL(endpoint);
+		String dir = outputDirectory + File.separatorChar + "solr" + File.separatorChar + item;
+		new File(dir).mkdirs();
+		FileUtils.write(
+				new File((dir + File.separatorChar) + (solrHost.replaceAll("/", "_"))),
+				output, Charset.forName("UTF-8"));
+		return output;
+	}
+
 
 	private static Map<String, String> dumpZkData(CuratorFramework client, String initialPath) throws Exception {
 		Map<String, String> zkDump = new LinkedHashMap<>();
@@ -151,6 +156,7 @@ public class SearchInsightsCollector
 	}
 
 	private static String fetchURL(String endpoint) throws IOException, MalformedURLException, ProtocolException {
+		endpoint += endpoint.contains("?")? "&_=searchscale": "?_=searchscale";
 		HttpURLConnection con = (HttpURLConnection) new URL(endpoint).openConnection();
 		con.setRequestMethod("GET");
 
@@ -178,12 +184,22 @@ public class SearchInsightsCollector
 		return solrHostURLs;
 	}
 
-	private static String getZKHosts(CommandLine cmd, String zkhost) throws ParseException {
+	private static String getZKHost(CommandLine cmd) throws ParseException {
+		String zkhost = null;
 		if(cmd.hasOption("c")) {
 			zkhost = cmd.getOptionValue("c");
 			System.out.println("ZK host is: " + zkhost);
 		}
 		return zkhost;
+	}
+
+	private static String[] getDirectSolrURLs(CommandLine cmd) throws ParseException {
+		String urls[] = null;
+		if(cmd.hasOption("d")) {
+			String arg = cmd.getOptionValue("d");
+			urls = arg.split(",");
+		}
+		return urls;
 	}
 
 }


### PR DESCRIPTION
* Support for direct Solr URLs (useful for Kubernetes like setups where only a few Solr hosts are exposed)
* disabling expensive operations (-e | --disable-expensive-operations)
* threads, logs, overseer & plugins endpoints collected
* Ability to specify cluster name (-n)
* Add a `_` param with value "searchscale" to all outgoing requests to Solr
* Added a collector.properties file containing the version number of the collector used.