### PR TITLE
Better error reporting for connecting to authenticated Solr clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Examples:
 
 Notes:
     
-* `clustername` is a required parameter. The generated file contains the cluster name in prefix. The name shouldn't contain spaces or special characters (other than '-').
+* `clustername` (or -n) is a required parameter. The generated file contains the cluster name in prefix. The name shouldn't contain spaces or special characters (other than '-').
 * `--zkhost` parameter is necessary if using `--collect-zk-metrics`
 * To supply Solr URLs directly, use `-d` parameter. If not specified, Solr URLs will be looked up in live_nodes of ZooKeeper (if `--zkhost` is specified)
 * To disable collection of logs and field metrics (Luke), you can add `--disable-expensive-operations` parameter


### PR DESCRIPTION
When Solr is unable to connect to an authenticated cluster, Solr throws 401 exception in both these cases:
1) no authentication headers are passed
2) wrong credentials are passed.

Solr outputs a helpful message distinguishing the two of these in its body. In this issue, we print back the body text in case of non 2xx requests.