### PR TITLE
Enable all except plugins by default. Add `--enable-plugins` flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ __pycache__
 # Ignore gradle wrapper
 gradle/wrapper/gradle-wrapper.jar
 .gradletasknamecache
+
+archives

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.searchscale.insights</groupId>
   <artifactId>search-insights-collector</artifactId>
   <packaging>jar</packaging>
-  <version>0.8.2</version>
+  <version>0.8.3</version>
   <name>search-insights-collector</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/search-insights-collector.sh
+++ b/search-insights-collector.sh
@@ -1,5 +1,5 @@
 ################### OPTIONS PARSING #####################
-VALID_ARGS=$(getopt -o ehszc:d:n:k: --long disable-expensive-operations,disable-segments,disable-threads,disable-plugins,disable-overseer,disable-luke,disable-logs,collect-host-metrics,collect-solr-metrics,collect-zk-metrics,zkhost:,keys:,cluster-name: -- "$@")
+VALID_ARGS=$(getopt -o ehszc:d:n:k: --long disable-expensive-operations,enable-plugins,collect-host-metrics,collect-solr-metrics,collect-zk-metrics,zkhost:,keys:,cluster-name: -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1;
 fi
@@ -14,29 +14,8 @@ while [ : ]; do
         JAVA_OPTS="$JAVA_OPTS --disable-expensive-operations"
         shift
         ;;
-    --disable-segments)
-        JAVA_OPTS="$JAVA_OPTS --disable-segments"
-        shift
-        ;;
-    --disable-threads)
-        DISABLE_THREADS="True"
-        JAVA_OPTS="$JAVA_OPTS --disable-threads"
-        shift
-        ;;
-    --disable-plugins)
-        JAVA_OPTS="$JAVA_OPTS --disable-plugins"
-        shift
-        ;;
-    --disable-threads)
-        JAVA_OPTS="$JAVA_OPTS --disable-threads"
-        shift
-        ;;
-    --disable-luke)
-        JAVA_OPTS="$JAVA_OPTS --disable-luke"
-        shift
-        ;;
-    --disable-logs)
-        JAVA_OPTS="$JAVA_OPTS --disable-logs"
+    --enable-plugins)
+        JAVA_OPTS="$JAVA_OPTS --enable-plugins"
         shift
         ;;
     -h | --collect-host-metrics)
@@ -115,7 +94,7 @@ then
 fi
 
 ######### COMPUTE THE SOLR and ZOOKEEPER METRICS ############
-java -cp search-insights-collector-0.8.2-jar-with-dependencies.jar:target/search-insights-collector-0.8.2-jar-with-dependencies.jar:. \
+java -cp search-insights-collector-0.8.3-jar-with-dependencies.jar:target/search-insights-collector-0.8.3-jar-with-dependencies.jar:. \
          com.searchscale.insights.SearchInsightsCollector --output-directory $OUTDIR $JAVA_OPTS
 
 #echo "JAVAOPTS: $JAVA_OPTS"


### PR DESCRIPTION
A code change to enable all except `plugins` by default. Now if plugins need to be collected the user will have to pass `--enable-plugins` flag. This flag will be ineffective when `--disable-expensive-operations` is passed.